### PR TITLE
fix: 날씨 데이터 시간대 정렬 시 누락된 fcstDate 및 fcstTime 필드 처리

### DIFF
--- a/client/script.js
+++ b/client/script.js
@@ -180,8 +180,12 @@ function groupWeatherData(items) {
 
     items.forEach(item => {
         const time = item.fcstTime;
+        const date = item.fcstDate;
         if (!grouped[time]) {
-            grouped[time] = {};
+            grouped[time] = {
+                fcstDate: date,
+                fcstTime: time,
+            };
         }
         grouped[time][item.category] = item.fcstValue;
     });


### PR DESCRIPTION
fix: 날씨 데이터 시간대 정렬 시 누락된 fcstDate 및 fcstTime 필드 처리

-날씨 데이터 시간대 정렬 시 누락된 fcstDate 및 fcstTime 필드 처리